### PR TITLE
Bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,14 @@
 
 ## Changelog
 
+#### 0.3
+
+* Fix default PATH for daemon startup.
+* Fix for kernels not responding node changes.
+* Limit checking for current to just once.
+* Minor UI change.
+* Documentations update.
+
 #### 0.2
 
 * Add examples for supported actions.

--- a/module.prop
+++ b/module.prop
@@ -20,8 +20,8 @@
 id=blex
 name=Battery Life Extender
 
-version=0.2
-versionCode=201810061
+version=0.3
+versionCode=201810161
 
 author=Jaymin Suthar
 description=blex helps in extending/maintaining lithium batteries' life by controlling when charging is enabled or disabled.


### PR DESCRIPTION
* Flags

    [--detach]

    Detach from the terminal and run as a background process.

    [--skip-logs]

    Skip dumping logs to the logfile (to improve performance).

    [--enforce]

    Enforce any value between 1-99 as a valid threshold and
    do not perform mathematics on arguments given.

    NOTE: Flags must be in order [--detach] > [--skip-logs] > [--enforce]
    or else blex will misinterpret them as options.

* Options

    [--update] [switch/power] [disable/power] [enable]

    Update Automation thresholds. The feature that provides
    the thresholds is the first argument and new values of
    thresholds are arguments following that.

    If the feature is Auto Power, second argument is power
    threshold, and if the feature is Auto Switch, second and
    third arguments are disable and enable thresholds as in
    order.

    If enable threshold is not given, it will figure that out,
    and if no threshold is given, it'll revert thresholds of
    the feature to their defaults, and finally, if the feature
    is not given, it will revert every threshold.

    [--toggle] [switch/power] [ON/OFF]

    Toggle Automation feature ON or OFF. The feature to toggle
    is the first argument and the state to toggle to is the
    second.

    If state is not given, it'll invert the feature state like
    ON -> OFF and vice versa, and if the feature is not given,
    both features will be reverted to their default state.

    [--manual] [enable/disable/stop] [level/time]

    Enable or disable charging, or stop every manual method
    running. The action to perform is the first argument and
    the format string for the action (if not stop) is second
    argument.

    If the action is stop, it will stop every manual method
    currently running, and if enable or disable, then charging
    state will be {action}d based on the format specified by
    the format string.

    The format string will be '{level}%' if {action}ing until
    the 'level' is hit, or '{time}s', '{time}m' or '{time}h'
    to {action} charging until 'time' seconds, 'time' minutes
    or 'time' hours have passed respectively.

    [--mkdaemon] [start/stop]

    Start or stop the blex daemon manually. It will start or
    stop the daemon as per the first argument.

    If an argument is not given, it will start the daemon.

    [--configure]

    Configure blex' kernel communication interface.

    [--restat]

    Reset battery statistics on demand. Useful in recalibraing
    the battery, should only be used once a month.

    [--info]

    Print information about current battery state, settings of
    blex and whether the daemon is running or not.

    [--help]

    Print this HELP page and exit.